### PR TITLE
PS-27363: Remove duplicate labels.

### DIFF
--- a/src/github.sh
+++ b/src/github.sh
@@ -17,8 +17,23 @@ github::add_label_to_pr() {
   local -r label_to_add=$2
 
   local -r body=$(curl -sSL -H "Authorization: token $GITHUB_TOKEN" -H "$GITHUB_API_HEADER" "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/pulls/$1")
-  local labels=$(echo "$body" | jq .labels | jq -r ".[] | .name" | grep -v "size/")
-  labels+=("$label_to_add")
+
+  local -r existing_labels=$(echo "$body" | jq .labels | jq -r ".[] | .name" | grep -v "size/")
+  log::message "Existing labels: $existing_labels"
+
+  for label in "super_easy" "easy" "bearable" "mind_blowing"; do
+    if echo "$existing_labels" | grep -q "$label"; then
+      log::message "Deleting label '$label'"
+      curl -sSL \
+        -H "Authorization: token $GITHUB_TOKEN" \
+        -H "$GITHUB_API_HEADER" \
+        -X DELETE \
+        "$GITHUB_API_URI/repos/$GITHUB_REPOSITORY/issues/$pr_number/labels/$label"
+    fi
+  done
+
+  local labels=$(echo "$existing_labels" | grep -v -E 'super_easy|easy|bearable|mind_blowing')
+  labels=("$label_to_add")
 
   local -r comma_separated_labels=$(github::format_labels "${labels[@]/#/}")
 

--- a/src/github.sh
+++ b/src/github.sh
@@ -9,7 +9,7 @@ github::calculate_total_modifications() {
   local -r additions=$(echo "$body" | jq '.additions')
   local -r deletions=$(echo "$body" | jq '.deletions')
 
-  echo $(( additions + deletions ))
+  echo $((additions + deletions))
 }
 
 github::add_label_to_pr() {


### PR DESCRIPTION
When we create pull request, script add new label. If we push more commits, size can be changed, but old labels still available. This fix remove old labels, before adding a new one.